### PR TITLE
Fix CI crash on windows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -26,6 +26,8 @@ jobs:
           add-pip-as-python-dependency: true
       - shell: bash -l {0}
         run: |
+          # Use conda to manage the building toolchain, but is now outdated
+          # https://numpy.org/doc/stable/f2py/windows/index.html
           conda install m2w64-toolchain libpython
           # numpy is required for pypolsys building. Better to install it with conda.
           # Sometime it fails when installed by pip thought `build-system` requirement from `pyproject.toml` 

--- a/pypolsys/__init__.py
+++ b/pypolsys/__init__.py
@@ -18,8 +18,26 @@
 # along with pypolsys.  If not, see <https://www.gnu.org/licenses/>.
 
 
-# not usefull to map all fortran modules
+# On windows (gfortran+msvc) the fortran dll are put in a `.libs` folder 
+# by numpy.distutils and need to be in the path before import
+# see https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#building-python-wheels-with-fortran-for-windows
+
+import os as _os
+import sys as _sys
+from platform import system as _system
+if _system() == "Windows":
+    extra_dll_dir = _os.path.join(_os.path.dirname(__file__), '.libs')
+    # For python < 3.8 use path
+    if _os.path.isdir(extra_dll_dir):
+        _os.environ["PATH"] += _os.pathsep + extra_dll_dir
+    # From python >= 3.8 ddl are managed with `os.add_dll_directory`
+    if _sys.version_info >= (3, 8):
+        if _os.path.isdir(extra_dll_dir):
+            _os.add_dll_directory(extra_dll_dir)
+
+# Not usefull to map all fortran modules
 from .polsys import polsyswrap as polsys
 from . import utils
 from .utils import solve_univar
 from .version import __version__
+

--- a/pypolsys/__init__.py
+++ b/pypolsys/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # This file is part of pypolsys, A python wrapper to `POLSYS_PLP`
 # fortran90 package from Layne T. Watson, Steven M. Wise,
 # Andrew J. Sommese, August, 1998.
@@ -17,8 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with pypolsys.  If not, see <https://www.gnu.org/licenses/>.
 
+r"""
+pypolsys -- A python wrapper to `POLSYS_PLP` fortran90 homotopy solver
+======================================================================
+.. include::../README.md
+    :start-line:4
+    :raw:
+"""
 
-# On windows (gfortran+msvc) the fortran dll are put in a `.libs` folder 
+# On windows (gfortran+msvc) the fortran dll are put in a `.libs` folder
 # by numpy.distutils and need to be in the path before import
 # see https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#building-python-wheels-with-fortran-for-windows
 
@@ -40,4 +46,3 @@ from .polsys import polsyswrap as polsys
 from . import utils
 from .utils import solve_univar
 from .version import __version__
-


### PR DESCRIPTION
The CI on windows crashes since few months because the import of compiled extensions was not done properly **on windows plateform**. The extension is compiled using the m2w64-toolchain conda package. After the package installation a `.libs` is created by the building tool chain (m2w64-gfortran + msvc) and should be added to the os path.

See also
  - https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#building-python-wheels-with-fortran-for-windows
  - https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew for python version > 3.8.