### PR TITLE
Fix bug in fortran report subroutine.

### DIFF
--- a/pypolsys/src/wrapper.f90
+++ b/pypolsys/src/wrapper.f90
@@ -654,7 +654,7 @@ do i=1, size(path_status)
         print*, '   The normal flow Newton iteration in STEPNX or ROOT_PLP failed'
         print*, '    to converge.  The error error tolerances TRACKTOL or FINALTOL may'
         print*, '    be too stringent.'
-      case (-7) 
+      case (7) 
         print*, '   ROOT_PLP failed to find a root in 10*NUMRR iterations.'    
     end select
   end if

--- a/pypolsys/utils.py
+++ b/pypolsys/utils.py
@@ -19,7 +19,7 @@
 
 """
 Define some utility functions to pass *easily* polynomials and variables
-partitions to `PPLSYS_PLP`.
+partitions to `POLSYS_PLP`.
 
 Changing the partition has a strong impact on the number of paths to track
 in the homotopy. `PPLSYS_PLP` supports


### PR DESCRIPTION
I found a typo in the select-case block. It should be `7` instead of `-7`.