### PR TITLE
Fix setuptools changes for editable installation mode in Action.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -34,6 +34,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install the package
       run: |
+        export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
         pip install -e .
     - name: Run tests
       run: |


### PR DESCRIPTION
Setuptools has changed the editable installation mode. Legacy behavior can be recovered using,
```
export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
```
To maintain the CI, I suggest to use it. The real modification to the `pyproject.toml` and/or to `setup.py` would be done in a second time.
 