### PR TITLE
Include original POLSYS README file in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include README.md
 include pypolsys/801/*.f90
 include pypolsys/801/*.f
 include pypolsys/801/*.DAT
+include pypolsys/801/README
 include pypolsys/src/wrapper.f90
 include pypolsys/src/polsys.pyf
 include pypolsys/examples/data/toy_model.npz


### PR DESCRIPTION
The file was missing in the source distribution package.