### PR TITLE
Use numpy legacy printing in tests to maintain doctest.

### DIFF
--- a/pypolsys/test.py
+++ b/pypolsys/test.py
@@ -25,6 +25,12 @@ from scipy.optimize import linear_sum_assignment
 import os
 import sys
 
+# Numpy 2.0 change default printing options making doctest failing.
+# https://numpy.org/neps/nep-0051-scalar-representation.html
+# Use legacy mode for testing
+if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
+    np.set_printoptions(legacy="1.25")
+
 
 def sort_ref_found(ref, r):
     """ Sort reference solution and the found solution using


### PR DESCRIPTION
Numpy 2.0 change the default printing options making doctest with scalar values failing.
see https://numpy.org/neps/nep-0051-scalar-representation.html

legacy:
```
>>> 2+np.int64(2)
4
```
New style:
```
>>> 2+np.int64(2)
np.int64(4)
```
This PR propose to use
```
np.set_printoptions(legacy="1.25")
```
Only in the test runner file.

Perhaps we could change the format in doctest when numpy 2 will be more common.
