### PR TITLE
Add an upper bound to `setuptools` in `pyproject.toml` to ensure compatibility

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -23,9 +23,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires=['setuptools', 'wheel', 'numpy']
+requires=['setuptools<60.0', 'wheel', 'numpy']


### PR DESCRIPTION
Add an upper bound to `setuptools` in `pyproject.toml` to ensure compatibility.

See https://numpy.org/devdocs/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools
for details.

Also update Github action version.