### PR TITLE
Limit setuptools in ci-windows.yml.

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,11 +15,11 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@main
+      - uses: conda-incubator/setup-miniconda@main
         with:
           activate-environment: polsys_env
-          python-version: 3.8
+          python-version: 3.11
           auto-activate-base: false
           miniconda-version: "latest"
           auto-update-conda: true
@@ -31,11 +31,12 @@ jobs:
           conda install m2w64-toolchain libpython
           # numpy is required for pypolsys building. Better to install it with conda.
           # Sometime it fails when installed by pip thought `build-system` requirement from `pyproject.toml` 
-          conda install numpy setuptools wheel
+          # Limit setuptools version because of numpy.distutils
+          conda install numpy "setuptools<60.0" wheel
       - name: Build
         shell: bash -l {0}
         run: |
-            # Ignore `pyproject.toml` to avoid conda/pip mix in numpy version
+            # Ignore `pyproject.toml` to avoid conda/pip mix in numpy version            
             python -m pip install -e . --no-use-pep517
             # Show f2py compiler info for debug
             f2py -c --help-fcompiler            


### PR DESCRIPTION
Windows CI doesn't use (for now) the `pyproject.toml` file and the modification from #20 doesn't affect the windows build.

This PR, also :
  - update python version to 3.11
  - update github action version
