### PR TITLE
Add a CI action to build wheel for macos, windows and Linux

### DIFF
--- a/.github/workflows/CI-build-release.yml
+++ b/.github/workflows/CI-build-release.yml
@@ -125,7 +125,7 @@ jobs:
 
   github-release:
     name: Create a GitHub Release
-    needs: [build_wheels, build_sdist, check_tag]
+    needs: publish-to-pypi
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/CI-build-release.yml
+++ b/.github/workflows/CI-build-release.yml
@@ -1,12 +1,15 @@
-name: Build wheels and sdist
+name: Publish Python 🐍 distribution 📦 to PyPI and create a github release
 
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +48,7 @@ jobs:
           name: wheel-${{ matrix.os }} 
           path: ./wheelhouse/*.whl
 
+
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
@@ -52,55 +56,90 @@ jobs:
       - uses: actions/checkout@main
 
       - name: Build sdist
-        run: pipx run build --sdist
+        run: pipx run build --sdist -o wheelhouse
 
       - uses: actions/upload-artifact@main
         with:
-          name: sourcedist 
-          path: dist/*.tar.gz
+          name: sdist
+          path: wheelhouse/*.tar.gz
 
 
-#  release:
-#    name: Release wheels and sdist
-#    # Edit here if compiling multiple papers
-#    needs: [build_wheels, build_sdist]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#      - uses: actions/download-artifact@v3
-#        with:
-#          path: build
-#      - name: move
-#        run: |
-#             mkdir -p github_deploy && mv build/*/* github_deploy && ls -l github_deploy
-#      - name: Release
-#        uses: softprops/action-gh-release@v1
-#        if: startsWith(github.ref, 'refs/tags/')
-#        with:
-#          # tag_name: SILEXlight-${{ github.event.release.tag_name }}
-#          name: SILEXlight release ${{ github.event.release.tag_name }}
-#          prerelease: false
-#          files: github_deploy/*
+  check_tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if head branch has a valid version tag
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.ref_name }}
+          regex: '^v[0-9]+.[0-9]+.[0-9]+'  # should we add final letters like 'beta'    
 
-  # upload_pypi:
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   # upload to PyPI on every tag starting with 'v'
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-  #   # alternatively, to publish when a GitHub Release is created, use the following rule:
-  #   # if: github.event_name == 'release' && github.event.action == 'published'
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         # unpacks default artifact into dist/
-  #         # if `name: artifact` is omitted, the action will create extra parent dir
-  #         name: artifact
-  #         path: dist
+      - uses: actions/checkout@main
 
-  #     - uses: pypa/gh-action-pypi-publish@v1.5.0
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.pypi_password }}
-  #         # To test: repository_url: https://test.pypi.org/legacy/
+      - name: Compare the tag and the package version
+        env: 
+          MATCH: ${{ steps.regex-match.outputs.match }}
+        run: |
+          echo "trig on push with:" ${{ github.ref }}  # when trig on tag, contains the tag
+          echo "full branch name": ${{ github.ref_name }}
+          echo "package tag:" $(python pypolsys/version.py)
+          echo "matched git tag:" $MATCH
+          if [[ v$(python pypolsys/version.py) == $MATCH ]]; then   # In version.py no 'v' prefix
+            echo "tags are identical, continue..."
+            exit 0;
+          else 
+            echo "tags are different. Stop."
+            exit 1;
+          fi
+
+         
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs: [build_wheels, build_sdist, check_tag]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pypolsys  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the build artifacts
+      uses: actions/download-artifact@main
+      with:
+        path: wheelhouse/
+    - name: Collect all wheels in the same path
+      run: |
+        ls -Rlrt wheelhouse
+        mkdir wheelhouse/all
+        mv -f wheelhouse/*/* wheelhouse/all/
+        echo "All the available wheels are:"
+        ls -lrt wheelhouse/all        
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1     
+      with:
+        packages-dir: wheelhouse/all
+
+
+  github-release:
+    name: Create a GitHub Release
+    needs: [build_wheels, build_sdist, check_tag]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create        
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --generate-notes
+        --title 'pypolsys ${{ github.ref_name }}'                   
 

--- a/.github/workflows/CI-build-release.yml
+++ b/.github/workflows/CI-build-release.yml
@@ -1,0 +1,106 @@
+name: Build wheels and sdist
+
+on: [push]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon 
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14] # ubuntu-24.04-arm, macos-13, macos-14, ubuntu-latest, windows-latest, macos-13 windows-latest
+        # os: [windows-latest] # ubuntu-24.04-arm, macos-13, macos-14, ubuntu-latest, windows-latest, macos-13 windows-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Provide gfortran (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          # Use rtools distribution of mingw64
+          # based on https://github.com/scipy/scipy/blob/main/.github/workflows/windows.yml
+          choco install rtools -y --no-progress --force --version=4.0.0.20220206
+          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@main
+        env:
+          CIBW_SKIP: "pp* *-musllinux* *-win32 *i686 cp38* cp39*"
+          CIBW_ARCHS_WINDOWS: native
+          #CIBW_ARCHS_MACOS: x86_64
+          # delocate-wheel ask to set the environment variable 'MACOSX_DEPLOYMENT_TARGET=13.0' to update minimum supported macOS for this wheel.
+          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
+          CIBW_ENVIRONMENT_MACOS: >
+             CC=gcc-13 CXX=g++-13 FC=gfortran-13
+             MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '13.0' }}
+          # CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=13.0"          
+          CIBW_ENVIRONMENT_WINDOWS: CC=gcc CXX=g++ FC=gfortran
+          CIBW_BEFORE_TEST: pip install pytest
+          CIBW_TEST_COMMAND: "pytest --pyargs pypolsys.test -v"
+
+      - uses: actions/upload-artifact@main
+        with:
+          name: wheel-${{ matrix.os }} 
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@main
+        with:
+          name: sourcedist 
+          path: dist/*.tar.gz
+
+
+#  release:
+#    name: Release wheels and sdist
+#    # Edit here if compiling multiple papers
+#    needs: [build_wheels, build_sdist]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#      - uses: actions/download-artifact@v3
+#        with:
+#          path: build
+#      - name: move
+#        run: |
+#             mkdir -p github_deploy && mv build/*/* github_deploy && ls -l github_deploy
+#      - name: Release
+#        uses: softprops/action-gh-release@v1
+#        if: startsWith(github.ref, 'refs/tags/')
+#        with:
+#          # tag_name: SILEXlight-${{ github.event.release.tag_name }}
+#          name: SILEXlight release ${{ github.event.release.tag_name }}
+#          prerelease: false
+#          files: github_deploy/*
+
+  # upload_pypi:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   # upload to PyPI on every tag starting with 'v'
+  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  #   # alternatively, to publish when a GitHub Release is created, use the following rule:
+  #   # if: github.event_name == 'release' && github.event.action == 'published'
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         # unpacks default artifact into dist/
+  #         # if `name: artifact` is omitted, the action will create extra parent dir
+  #         name: artifact
+  #         path: dist
+
+  #     - uses: pypa/gh-action-pypi-publish@v1.5.0
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.pypi_password }}
+  #         # To test: repository_url: https://test.pypi.org/legacy/
+

--- a/README.md
+++ b/README.md
@@ -36,28 +36,40 @@ To facilitate the build of this module, a copy of `POLSYS_PLP` *original* source
 
 ## Installation
 
-You'll need :
-  * python (tested for v >= 3.8);
-  * pip (optional);
-  * fortran compiler (tested with `gfortran` and with `m2w64-toolchain` on windows)
-  * lapack and blas installation (only on linux). The useful lapack/blas routines are also shipped with `POLSYS_PLP` sources and built by default on Window or on demand on linux (see below). Optimized library are preferred and often already present on linux systems. If not, library like `openblas` and the required development files can be installed with `sudo apt install libopenblas-dev` on debian based distribution (including ubuntu).
-
-If needed, please see the steps given in the continuous integration scripts [ci-ubuntu](.github/workflows/ci-ubuntu.yml) or [ci-windows](.github/workflows/ci-windows.yml). 
-
-### Using pip
+### From the wheel
+The easiest way to install `pypolsys` is to use the wheel available on pypi. Wheels are availlable for the most usual 64 bits architectures and os (Linux, Windows, Macos).
 You can install `pypolsys` from pip:
 ```
 pip install pypolsys [--user]
 ```
-You can also install `pypolsys` after a download from github or after cloning the repos:
+you can also use a virtual environnement for better isolation.
+
+### From the source
+If wheels are not available or if you need to modify the code or the last developpement version, you need to build `pypolsys` from the source. The sources are available on pypi or on the github [repos](https://github.com/nennigb/pypolsys/).
+
+You'll need :
+  * python (tested for v >= 3.10);
+  * pip;
+  * fortran compiler (tested with `gfortran` on linux and macos, with `m2w64-toolchain` on windows with conda or with `rtools` distribution of `mingw64`);
+  * lapack and blas installation (only on linux), optional. The useful lapack/blas routines are also shipped with `POLSYS_PLP` sources and built by default on Window or on demand on linux (see below). Optimized library are preferred and often already present on linux systems. If not, library like `openblas` and the required development files can be installed with `sudo apt install libopenblas-dev` on debian based distribution (including ubuntu).
+
+After, just use
 ```
-pip install path/to/pypolsys-version.tar.gz [--user]
+pip install pypolsys [--user]
 ```
-Installation can be done _editable_ mode if you want to modify the sources:
+it will download the source from pypi and build `pypolsys`.
+If you manualy get the sources, in the `pypolsys` source folder (where there is the `meson.build` file), run
 ```
-python -m pip install --no-build-isolation --editable .
+pip install .
 ```
-In this case, compatible version of meson, meson-python and ninja have to be installed before (see `pyproject.toml` file).
+or,
+```
+pip install -v --no-build-isolation --editable .
+```
+to install it in editable mode.
+
+If needed, please see the steps given in the continuous integration scripts [ci-ubuntu](.github/workflows/ci-ubuntu.yml), [ci-windows](.github/workflows/ci-windows.yml) or [CI-build-release.yml](.github/workflows/CI-build-release.yml).
+
 
 ### Running tests
 To execute the full test suite, run :
@@ -67,7 +79,6 @@ python -m pypolsys.test
 
 ### Troubleshooting
 With old `gfortran` version present on ubuntu 16.04 (see [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84276)) the building may failed. To avoid this, `intent(in, out)` statement has to be removed from the original `pypolsys/801/polsys_plp.f90`. It seems to work out of the box with `gfortan-8`.
-
 
 ## Usage
 Note that this projet is a work in progress and the API may change.
@@ -92,7 +103,7 @@ n_coef_per_eq = np.array([4, 4, 4], dtype=np.int32)
 # Provide the coefficients as 1D array
 all_coef = np.array([1, 1,  1, -1,
                      1, 1,  1, -1,
-                     1, 1,  1, -1], dtype=np.complex)
+                     1, 1,  1, -1], dtype=complex)
 # then the degree of each monom
 all_deg = np.zeros((np.sum(n_coef_per_eq), N), dtype=np.int32)
 all_deg[0, 0] = 2
@@ -204,4 +215,4 @@ If you need to modify `wrapper.f90` fortran source file. You will need to re-bui
 This file is part of pypolsys, a simple python wrapper to fortran package polsys_plp.
 pypolsys is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 pypolsys is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with amc2moodle.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License along with pypolsys.  If not, see <https://www.gnu.org/licenses/>.

--- a/meson.build
+++ b/meson.build
@@ -1,17 +1,20 @@
 project(
     'pypolsys',
-    'c',
+    ['c', 'fortran'],
     version: run_command('pypolsys/version.py', check: true).stdout().strip(),
     license: 'GNU General Public License v3 (GPLv3)',
     meson_version: '>=0.64.0',
     default_options: ['warning_level=2', 'buildtype=release'],
 )
 
+
 add_languages('fortran', native: true)
 # load meson python module
 py_mod = import('python')
 py = py_mod.find_installation(pure: false)
 py_dep = py.dependency()
+# https://github.com/numpy/numpy/issues/25000
+quadmath_dep = meson.get_compiler('fortran', native: true).find_library('quadmath', required:false)
 
 # Get include from numpy and f2py
 # based on https://numpy.org/doc/stable/f2py/buildtools/meson.html
@@ -63,11 +66,22 @@ src_files = [
     'pypolsys/801/polsys_plp.f90',
     'pypolsys/src/wrapper.f90',
 ]
-# Lapack
-lapack_dep = dependency('lapack', required: false)
-if not lapack_dep.found()
-    # Need to compile lapack too
-    src_files += 'pypolsys/801/lapack_plp.f'
+
+# Look for lapack only on linux
+# Check the operating system the code is runnig (will failed for cross compilation=)
+deps = [py_dep, quadmath_dep]
+if host_machine.system() == 'linux'
+  lapack_dep = dependency('lapack', required: false)
+  if not lapack_dep.found()
+      # Need to compile lapack too
+      src_files += 'pypolsys/801/lapack_plp.f'
+  else
+      deps += lapack_dep    
+  endif
+else
+  lapack_dep = disabler()
+  # Need to compile lapack too
+  src_files += 'pypolsys/801/lapack_plp.f'
 endif
 
 # Assumes that f2py was run before in _polsys_module
@@ -77,9 +91,8 @@ py.extension_module(
     incdir_f2py / 'fortranobject.c',
     include_directories: inc_np,
     # No problem if lapack_dep is not found, meson just ignore it
-    dependencies: [py_dep, lapack_dep],
+    dependencies: deps,
     install: true,
-    link_language: 'fortran',
     native: true,
     subdir: 'pypolsys',  # Folder relative to site-packages to install to
 )
@@ -104,5 +117,4 @@ py.install_sources(
 # Add package_data used for tests as source files
 install_dir = py.get_install_dir(subdir: 'pypolsys/examples/data')
 install_data('pypolsys/examples/data/toy_model.npz', install_dir: install_dir)  # / 'examples' / 'data'
-
 

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ inc_np = include_directories(incdir_numpy, incdir_f2py)
 
 # Copy .f2py_f2cmap in buildir (f2py needs it in the working dir)
 fs = import('fs')
-fs.copyfile('.f2py_f2cmap')
+f2py_f2cmap = fs.copyfile('.f2py_f2cmap')
 _polsys_module = custom_target(
     'polsys',
     output: [
@@ -58,6 +58,7 @@ _polsys_module = custom_target(
         'polsys-f2pywrappers.f',
     ],
     input: ['pypolsys/src/polsys.pyf'],
+    depends: f2py_f2cmap,
     command: [py, '-m', 'numpy.f2py', '@INPUT@', '--lower'],
 )
 # Pypolsys extension own src files

--- a/pypolsys/version.py
+++ b/pypolsys/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
This PR provides a github action to build wheels for all maintained python versions on most OS.
To create a new pypi or github release, we need to push a tag `v*.*.*` on the master branch.

On windows, the build was tricky and I use the mingw64 distribution include in `rtools` as in scipy.
It is noteworthy that with
```
        uses: msys2/setup-msys2@v2
        with:
          msystem: MINGW64
          release: false          
          path-type: inherit
          install: >-
            mingw-w64-x86_64-gcc-fortran
```
it success to build, but failed at import time.
Another lock was the missing implicit deps `libquadmath`. This later is now added explicitly added if present.

The `meson.build` has also been modified to copy first `f2py_f2cmap`. Indeed, the the build steps execution  is not fully deterministic across the platform.


